### PR TITLE
Increment by five feature

### DIFF
--- a/brainfuck/commands.go
+++ b/brainfuck/commands.go
@@ -6,7 +6,7 @@ type command interface {
 	execute(mem *memory)
 }
 
-//	Moves pointer in memory to right
+// moveForward moves pointer in memory to right
 type moveForward struct{}
 
 func (moveForward) execute(mem *memory) {
@@ -16,35 +16,35 @@ func (moveForward) execute(mem *memory) {
 	mem.ptr++
 }
 
-// Moves pointer in memory to left
+// moveBackward moves pointer in memory to left
 type moveBackward struct{}
 
 func (moveBackward) execute(mem *memory) {
 	mem.ptr--
 }
 
-// Increments current memory buffer's cell by one
+// increment Increments current memory buffer's cell by one
 type increment struct{}
 
 func (increment) execute(mem *memory) {
 	mem.buffer[mem.ptr]++
 }
 
-//	Decrements current memory buffer's cell by one
+// decrement decrements current memory buffer's cell by one
 type decrement struct{}
 
 func (decrement) execute(mem *memory) {
 	mem.buffer[mem.ptr]--
 }
 
-// Prints value of current memory buffer's cell to console
+// output prints value of current memory buffer's cell to console
 type output struct{}
 
 func (output) execute(mem *memory) {
 	fmt.Print(string(mem.buffer[mem.ptr]))
 }
 
-// Executes commands in loop until memory buffer's current cell is non-zero
+// loop executes commands in loop until memory buffer's current cell is non-zero
 type loop struct {
 	commands []command
 }
@@ -57,7 +57,7 @@ func (l loop) execute(mem *memory) {
 	}
 }
 
-// Increments current memory buffer's cell by five
+// incrementByFive Increments current memory buffer's cell by five
 type incrementByFive struct{}
 
 func (incrementByFive) execute(mem *memory) {

--- a/brainfuck/commands.go
+++ b/brainfuck/commands.go
@@ -56,3 +56,12 @@ func (l loop) execute(mem *memory) {
 		}
 	}
 }
+
+// Increments current memory buffer's cell by five
+type incrementByFive struct{}
+
+func (incrementByFive) execute(mem *memory) {
+	for i := 0; i < 5; i++ {
+		mem.buffer[mem.ptr]++
+	}
+}

--- a/brainfuck/commands_test.go
+++ b/brainfuck/commands_test.go
@@ -45,6 +45,12 @@ func TestSimpleCommands_Execute(t *testing.T) {
 			args:     args{memory: newMemory([]byte{0, 0, 0}, 2)},
 			expected: *newMemory([]byte{0, 0, 0}, 1),
 		},
+		{
+			name:     "should increment buffer's cell with index [0] by five",
+			command:  incrementByFive{},
+			args:     args{memory: newMemory([]byte{0}, 0)},
+			expected: *newMemory([]byte{5}, 0),
+		},
 	}
 
 	for _, tt := range tests {

--- a/brainfuck/doc.go
+++ b/brainfuck/doc.go
@@ -1,7 +1,11 @@
 /*
 Package brainfuck provides a functionality of interpreter of BrainFuck programming language.
 
-Available instructions: "+", "-", ">", "<", "[", "]", ".".
+Available instructions:
+
+base: "+", "-", ">", "<", "[", "]", ".".
+
+custom: "$" - increment by five
 
 	Note:
 Characters in input BrainFuck program that does not match any available instruction will be ignored.

--- a/brainfuck/parser.go
+++ b/brainfuck/parser.go
@@ -57,8 +57,7 @@ func replaceRepeatedInstructions(program string) string {
 	optimized := program
 
 	for seq, symbol := range repeatedInstructions {
-		cleared := strings.ReplaceAll(optimized, string(symbol), "") // delete all entries of the symbol
-		optimized = strings.ReplaceAll(cleared, seq, string(symbol))
+		optimized = strings.ReplaceAll(optimized, seq, string(symbol))
 	}
 
 	return optimized

--- a/brainfuck/parser.go
+++ b/brainfuck/parser.go
@@ -1,5 +1,7 @@
 package brainfuck
 
+import "strings"
+
 type parser struct {
 	stack [][]command
 	ptr   int
@@ -15,6 +17,8 @@ func newParser() *parser {
 // parse function constructs sequence of commands base on input string
 // all third party symbols in input will be ignored
 func (p *parser) parse(input string) []command {
+	input = replaceRepeatedInstructions(input)
+
 	for _, char := range input {
 		p.parseInstruction(char)
 	}
@@ -41,4 +45,19 @@ func (p *parser) parseInstruction(char rune) {
 		p.stack = p.stack[:p.ptr]
 		p.ptr--
 	}
+}
+
+var repeatedInstructions = map[string]rune{
+	"+++++": '$',
+}
+
+func replaceRepeatedInstructions(program string) string {
+	optimized := program
+
+	for seq, symbol := range repeatedInstructions {
+		cleared := strings.ReplaceAll(optimized, string(symbol), "") // delete all entries of the symbol
+		optimized = strings.ReplaceAll(cleared, seq, string(symbol))
+	}
+
+	return optimized
 }

--- a/brainfuck/parser.go
+++ b/brainfuck/parser.go
@@ -44,6 +44,8 @@ func (p *parser) parseInstruction(char rune) {
 		p.stack[p.ptr-1] = append(p.stack[p.ptr-1], loop{p.stack[p.ptr]})
 		p.stack = p.stack[:p.ptr]
 		p.ptr--
+	case '$':
+		p.stack[p.ptr] = append(p.stack[p.ptr], incrementByFive{})
 	}
 }
 

--- a/brainfuck/parser_test.go
+++ b/brainfuck/parser_test.go
@@ -16,18 +16,18 @@ func TestParser_parse(t *testing.T) {
 	}{
 		{
 			name: "should parse proper input",
-			args: args{"[+-><.]"},
+			args: args{"[++++++-><.]"},
 			expected: []command{
 				loop{
 					[]command{
-						increment{}, decrement{}, moveForward{}, moveBackward{}, output{},
+						incrementByFive{}, increment{}, decrement{}, moveForward{}, moveBackward{}, output{},
 					},
 				},
 			},
 		},
 		{
 			name:     "should skip third party symbols in input",
-			args:     args{"+#-@><)."},
+			args:     args{"+$#-@><)."},
 			expected: []command{increment{}, decrement{}, moveForward{}, moveBackward{}, output{}},
 		},
 	}

--- a/brainfuck/parser_test.go
+++ b/brainfuck/parser_test.go
@@ -16,11 +16,11 @@ func TestParser_parse(t *testing.T) {
 	}{
 		{
 			name: "should parse proper input",
-			args: args{"[++++++-><.]"},
+			args: args{"[++++++-><.$]"},
 			expected: []command{
 				loop{
 					[]command{
-						incrementByFive{}, increment{}, decrement{}, moveForward{}, moveBackward{}, output{},
+						incrementByFive{}, increment{}, decrement{}, moveForward{}, moveBackward{}, output{}, incrementByFive{},
 					},
 				},
 			},
@@ -28,7 +28,7 @@ func TestParser_parse(t *testing.T) {
 		{
 			name:     "should skip third party symbols in input",
 			args:     args{"+$#-@><)."},
-			expected: []command{increment{}, decrement{}, moveForward{}, moveBackward{}, output{}},
+			expected: []command{increment{}, incrementByFive{}, decrement{}, moveForward{}, moveBackward{}, output{}},
 		},
 	}
 


### PR DESCRIPTION
Added replacing repeated increment instructions into single instruction feature
Changes:
- Added `incrementByFive` commands to `commands.go`
- Modified `parser` with usage of new `replaceRepeatedInstructions` function to transform input of `parse` function
- Added tests for `incrementByFive` command

Tests result:
<img width="506" alt="Screenshot 2022-03-22 at 18 43 22" src="https://user-images.githubusercontent.com/93770275/159531258-9d592b4d-9b30-4617-98f8-2e01efc802ec.png">

